### PR TITLE
Check Terramate Version & Break out if failure

### DIFF
--- a/tmutils/tm-check.go
+++ b/tmutils/tm-check.go
@@ -2,6 +2,7 @@ package tmutils
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 )
 
@@ -10,7 +11,10 @@ func CheckVersion() {
 
 	output, err := cmd.Output()
 	if err != nil {
-		fmt.Println("Error: ", err)
+		fmt.Println("Error checking terramate version. Please verify it is installed.")
+		fmt.Println("Please check the terramate documentation for details: https://terramate.io/docs/cli/installation")
+		fmt.Println("Error Details: ", err)
+		os.Exit(1)
 	}
 
 	fmt.Println("Current Terramate Version: " + string(output))


### PR DESCRIPTION
added new feature to check version of terramate, will break out of the program is terramate is not found or returns an error